### PR TITLE
Add line height and font family parsing for text nodes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13,14 +13,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const dotenv_1 = __importDefault(require("dotenv"));
+const fetchFigmaFile_1 = require("./utils/fetchFigmaFile");
+const walkAndParse_1 = require("./walker/walkAndParse");
 dotenv_1.default.config();
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
-        const fileKey = process.env.FIGMA_FILE_KEY;
-        if (!fileKey) {
-            console.error("Please set the FIGMA_FILE_KEY environment variable.");
-            process.exit(1);
-        }
+        const json = yield (0, fetchFigmaFile_1.fetchFigmaFile)();
+        const parsed = (0, walkAndParse_1.walkAndParse)(json.document);
     });
 }
 main().catch((error) => {

--- a/dist/parser/parseNode.js
+++ b/dist/parser/parseNode.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseNode = parseNode;
+const parseTextNode_1 = require("./parseTextNode");
+function parseNode(node) {
+    switch (node.type) {
+        case "TEXT":
+            return (0, parseTextNode_1.parseTextNode)(node);
+        default:
+            return null;
+    }
+}

--- a/dist/parser/parseTextNode.js
+++ b/dist/parser/parseTextNode.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseTextNode = parseTextNode;
+function parseTextNode(node) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+    return {
+        type: "text",
+        content: (_a = node.characters) !== null && _a !== void 0 ? _a : "",
+        style: {
+            fontSize: (_b = node.style) === null || _b === void 0 ? void 0 : _b.fontSize,
+            fontWeight: (_c = node.style) === null || _c === void 0 ? void 0 : _c.fontWeight,
+            lineHeight: typeof ((_d = node.style) === null || _d === void 0 ? void 0 : _d.lineHeightPercentFontSize) === "number"
+                ? node.style.lineHeightPercentFontSize / 100
+                : typeof ((_e = node.style) === null || _e === void 0 ? void 0 : _e.lineHeightPx) === "number" &&
+                    typeof ((_f = node.style) === null || _f === void 0 ? void 0 : _f.fontSize) === "number"
+                    ? node.style.lineHeightPx / node.style.fontSize
+                    : undefined,
+            fontFamily: (_g = node.style) === null || _g === void 0 ? void 0 : _g.fontFamily,
+            color: ((_j = (_h = node.fills) === null || _h === void 0 ? void 0 : _h[0]) === null || _j === void 0 ? void 0 : _j.color)
+                ? rgbaFromColor(node.fills[0].color)
+                : undefined,
+        },
+    };
+}
+function rgbaFromColor(c) {
+    const r = Math.round(c.r * 255);
+    const g = Math.round(c.g * 255);
+    const b = Math.round(c.b * 255);
+    const a = c.a !== undefined ? c.a : 1;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+}

--- a/dist/types/node-element.js
+++ b/dist/types/node-element.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/utils/fetchFigmaFile.js
+++ b/dist/utils/fetchFigmaFile.js
@@ -1,0 +1,41 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fetchFigmaFile = fetchFigmaFile;
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+function fetchFigmaFile() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const token = process.env.FIGMA_TOKEN;
+        const fileKey = process.env.FIGMA_FILE_KEY;
+        if (!token)
+            throw new Error("FIGMA_TOKEN not set");
+        if (!fileKey)
+            throw new Error("FIGMA_FILE_KEY not set");
+        const res = yield fetch(`https://api.figma.com/v1/files/${fileKey}`, {
+            headers: {
+                "X-Figma-Token": token,
+            },
+        });
+        if (!res.ok) {
+            const msg = yield res.text();
+            throw new Error(`Figma API error: ${res.status} ${msg}`);
+        }
+        const data = yield res.json();
+        const filePath = path_1.default.resolve(process.cwd(), "figma-fetch-debug.json");
+        fs_1.default.writeFileSync(filePath, JSON.stringify(data.document.children, null, 2), "utf-8");
+        console.log(`📦 fetch result saved to ${filePath}`);
+        return data;
+    });
+}

--- a/dist/walker/walkAndParse.js
+++ b/dist/walker/walkAndParse.js
@@ -1,0 +1,52 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.walkAndParse = walkAndParse;
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const parseNode_1 = require("../parser/parseNode");
+function walkAndParse(root) {
+    const result = {
+        pages: [],
+        layouts: [],
+        components: [],
+    };
+    function walk(node) {
+        const parsedNode = (0, parseNode_1.parseNode)(node);
+        const { id, name, type } = node;
+        if (!name || typeof name !== "string")
+            return null;
+        if (name.startsWith("ignore:"))
+            return null;
+        const children = [];
+        if (Array.isArray(node.children)) {
+            for (const child of node.children) {
+                const parsedChild = walk(child);
+                if (parsedChild)
+                    children.push(parsedChild);
+            }
+        }
+        const nodeMeta = Object.assign({ id,
+            name,
+            type, style: parsedNode && "style" in parsedNode ? parsedNode.style : {}, content: parsedNode && "content" in parsedNode ? parsedNode.content : null }, (children.length > 0 ? { children } : {}));
+        if (name.startsWith("page:")) {
+            result.pages.push(nodeMeta);
+            return null;
+        }
+        else if (name.startsWith("layout:")) {
+            result.layouts.push(nodeMeta);
+            return null;
+        }
+        else if (type === "COMPONENT") {
+            result.components.push(nodeMeta);
+            return null;
+        }
+        return nodeMeta;
+    }
+    walk(root);
+    const filePath = path_1.default.resolve(process.cwd(), "figma-walk-result-debug.json");
+    fs_1.default.writeFileSync(filePath, JSON.stringify(result, null, 2), "utf-8");
+    return result;
+}

--- a/src/parser/parseTextNode.ts
+++ b/src/parser/parseTextNode.ts
@@ -7,6 +7,14 @@ export function parseTextNode(node: any): TextNode {
     style: {
       fontSize: node.style?.fontSize,
       fontWeight: node.style?.fontWeight,
+      lineHeight:
+        typeof node.style?.lineHeightPercentFontSize === "number"
+          ? node.style.lineHeightPercentFontSize / 100
+          : typeof node.style?.lineHeightPx === "number" &&
+            typeof node.style?.fontSize === "number"
+          ? node.style.lineHeightPx / node.style.fontSize
+          : undefined,
+      fontFamily: node.style?.fontFamily,
       color: node.fills?.[0]?.color
         ? rgbaFromColor(node.fills[0].color)
         : undefined,

--- a/src/types/node-element.ts
+++ b/src/types/node-element.ts
@@ -33,4 +33,6 @@ export type StyleProps = {
   fontSize?: number;
   fontWeight?: number;
   color?: string;
+  lineHeight?: number;
+  fontFamily?: string;
 };


### PR DESCRIPTION
## 概要
- テキストノードのスタイルに lineHeight と fontFamily を追加で解析
- スタイル型に lineHeight と fontFamily を追加

## テスト
- `npm run dev` (失敗: ENETUNREACH)
- `npx tsc`
- `npm test` (失敗: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a4c11bca7c833193b46c78b22f309a