### PR TITLE
Round line height to two decimals

### DIFF
--- a/dist/parser/parseTextNode.js
+++ b/dist/parser/parseTextNode.js
@@ -3,18 +3,21 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.parseTextNode = parseTextNode;
 function parseTextNode(node) {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+    const lineHeightValue = typeof ((_a = node.style) === null || _a === void 0 ? void 0 : _a.lineHeightPercentFontSize) === "number"
+        ? node.style.lineHeightPercentFontSize / 100
+        : typeof ((_b = node.style) === null || _b === void 0 ? void 0 : _b.lineHeightPx) === "number" &&
+            typeof ((_c = node.style) === null || _c === void 0 ? void 0 : _c.fontSize) === "number"
+            ? node.style.lineHeightPx / node.style.fontSize
+            : undefined;
     return {
         type: "text",
-        content: (_a = node.characters) !== null && _a !== void 0 ? _a : "",
+        content: (_d = node.characters) !== null && _d !== void 0 ? _d : "",
         style: {
-            fontSize: (_b = node.style) === null || _b === void 0 ? void 0 : _b.fontSize,
-            fontWeight: (_c = node.style) === null || _c === void 0 ? void 0 : _c.fontWeight,
-            lineHeight: typeof ((_d = node.style) === null || _d === void 0 ? void 0 : _d.lineHeightPercentFontSize) === "number"
-                ? node.style.lineHeightPercentFontSize / 100
-                : typeof ((_e = node.style) === null || _e === void 0 ? void 0 : _e.lineHeightPx) === "number" &&
-                    typeof ((_f = node.style) === null || _f === void 0 ? void 0 : _f.fontSize) === "number"
-                    ? node.style.lineHeightPx / node.style.fontSize
-                    : undefined,
+            fontSize: (_e = node.style) === null || _e === void 0 ? void 0 : _e.fontSize,
+            fontWeight: (_f = node.style) === null || _f === void 0 ? void 0 : _f.fontWeight,
+            lineHeight: typeof lineHeightValue === "number"
+                ? Math.round(lineHeightValue * 100) / 100
+                : undefined,
             fontFamily: (_g = node.style) === null || _g === void 0 ? void 0 : _g.fontFamily,
             color: ((_j = (_h = node.fills) === null || _h === void 0 ? void 0 : _h[0]) === null || _j === void 0 ? void 0 : _j.color)
                 ? rgbaFromColor(node.fills[0].color)

--- a/src/parser/parseTextNode.ts
+++ b/src/parser/parseTextNode.ts
@@ -1,6 +1,14 @@
 import { TextNode } from "../types/node-element";
 
 export function parseTextNode(node: any): TextNode {
+  const lineHeightValue =
+    typeof node.style?.lineHeightPercentFontSize === "number"
+      ? node.style.lineHeightPercentFontSize / 100
+      : typeof node.style?.lineHeightPx === "number" &&
+          typeof node.style?.fontSize === "number"
+        ? node.style.lineHeightPx / node.style.fontSize
+        : undefined;
+
   return {
     type: "text",
     content: node.characters ?? "",
@@ -8,11 +16,8 @@ export function parseTextNode(node: any): TextNode {
       fontSize: node.style?.fontSize,
       fontWeight: node.style?.fontWeight,
       lineHeight:
-        typeof node.style?.lineHeightPercentFontSize === "number"
-          ? node.style.lineHeightPercentFontSize / 100
-          : typeof node.style?.lineHeightPx === "number" &&
-            typeof node.style?.fontSize === "number"
-          ? node.style.lineHeightPx / node.style.fontSize
+        typeof lineHeightValue === "number"
+          ? Math.round(lineHeightValue * 100) / 100
           : undefined,
       fontFamily: node.style?.fontFamily,
       color: node.fills?.[0]?.color


### PR DESCRIPTION
## 概要
- lineHeight を小数点第2位まで丸める処理を追加しました。

## テスト
- `npm test` ("Error: no test specified" により失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a4c6aa7500833180ecfb2f6fec2018