### PR TITLE
FRAMEノードを処理するパーサーの雛形を追加

### DIFF
--- a/src/parser/parseFrameNode.ts
+++ b/src/parser/parseFrameNode.ts
@@ -1,0 +1,10 @@
+import { BoxNode } from "../types/node-element";
+
+// TODO: Implement FRAME node parsing logic
+export function parseFrameNode(node: any): BoxNode {
+  return {
+    type: "box",
+    children: [],
+  };
+}
+

--- a/src/parser/parseNode.ts
+++ b/src/parser/parseNode.ts
@@ -1,8 +1,11 @@
 import { NodeElement } from "../types/node-element";
 import { parseTextNode } from "./parseTextNode";
+import { parseFrameNode } from "./parseFrameNode";
 
 export function parseNode(node: any): NodeElement | null {
   switch (node.type) {
+    case "FRAME":
+      return parseFrameNode(node);
     case "TEXT":
       return parseTextNode(node);
     default:


### PR DESCRIPTION
## 概要
- FRAMEタイプに対応する`parseFrameNode`の雛形を作成
- `parseNode`でFRAMEタイプを判定し`parseFrameNode`を呼び出すように修正

## テスト
- `npm test`（テスト未定義のためエラー終了）

------
https://chatgpt.com/codex/tasks/task_e_68a4e2af7c0c8331b08e52fc126d3388