### PR TITLE
frameノードのprefix判定と背景色処理を追加

### DIFF
--- a/src/parser/parseFrameNode.ts
+++ b/src/parser/parseFrameNode.ts
@@ -1,10 +1,37 @@
-import { BoxNode } from "../types/node-element";
+import { FrameNode, BoxNode, NodeElement } from "../types/node-element";
+import { parseNode } from "./parseNode";
 
-// TODO: Implement FRAME node parsing logic
-export function parseFrameNode(node: any): BoxNode {
-  return {
-    type: "box",
-    children: [],
-  };
+export function parseFrameNode(node: any): FrameNode | BoxNode {
+  const style: Record<string, any> = {};
+
+  if (node.fills?.[0]?.color) {
+    style.backgroundColor = rgbaFromColor(node.fills[0].color);
+  }
+
+  const children: NodeElement[] = Array.isArray(node.children)
+    ? node.children
+        .map((child: any) => parseNode(child))
+        .filter((c: NodeElement | null): c is NodeElement => c !== null)
+    : [];
+
+  const name = node.name ?? "";
+  if (
+    name.startsWith("page:") ||
+    name.startsWith("layout:") ||
+    name.startsWith(":page") ||
+    name.startsWith(":layout")
+  ) {
+    return { type: "frame", style, children };
+  }
+
+  return { type: "box", style, children };
+}
+
+function rgbaFromColor(c: any): string {
+  const r = Math.round(c.r * 255);
+  const g = Math.round(c.g * 255);
+  const b = Math.round(c.b * 255);
+  const a = c.a !== undefined ? c.a : 1;
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
 }
 

--- a/src/types/node-element.ts
+++ b/src/types/node-element.ts
@@ -1,10 +1,23 @@
-export type NodeElement = BoxNode | TextNode | ImageNode | InstanceNode;
-
 export type BaseNode = {
   name?: string;
   id?: string;
   props?: Record<string, string>;
   static?: boolean;
+};
+
+export type StyleProps = {
+  fontSize?: number;
+  fontWeight?: number;
+  color?: string;
+  lineHeight?: number;
+  fontFamily?: string;
+  backgroundColor?: string;
+};
+
+export type FrameNode = BaseNode & {
+  type: "frame";
+  children: NodeElement[];
+  style?: StyleProps;
 };
 
 export type BoxNode = BaseNode & {
@@ -29,10 +42,9 @@ export type InstanceNode = BaseNode & {
   componentName: string;
 };
 
-export type StyleProps = {
-  fontSize?: number;
-  fontWeight?: number;
-  color?: string;
-  lineHeight?: number;
-  fontFamily?: string;
-};
+export type NodeElement =
+  | FrameNode
+  | BoxNode
+  | TextNode
+  | ImageNode
+  | InstanceNode;


### PR DESCRIPTION
## 概要
- page/layoutプレフィックスを持つフレームを frame タイプとしてパース
- fills 設定から背景色を style.backgroundColor に反映
- 型定義に FrameNode と backgroundColor を追加

## テスト
- `npx tsc --noEmit`
- `npm test` (no test specified により失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a4e5ed375c8331a75ae1850e829c49