### PR TITLE
Add flex layout handling and padding to frame parser

### DIFF
--- a/src/parser/parseFrameNode.ts
+++ b/src/parser/parseFrameNode.ts
@@ -16,6 +16,24 @@ export function parseFrameNode(node: any): FrameNode | BoxNode {
     style.backgroundColor = rgbaFromColor(node.fills[0].color);
   }
 
+  if (node.layoutMode === "HORIZONTAL") {
+    style.display = "flex";
+    style.flexDirection = "row";
+  }
+
+  if (typeof node.paddingTop === "number") {
+    style.paddingTop = node.paddingTop;
+  }
+  if (typeof node.paddingRight === "number") {
+    style.paddingRight = node.paddingRight;
+  }
+  if (typeof node.paddingBottom === "number") {
+    style.paddingBottom = node.paddingBottom;
+  }
+  if (typeof node.paddingLeft === "number") {
+    style.paddingLeft = node.paddingLeft;
+  }
+
   return { type: "box", style };
 }
 

--- a/src/types/node-element.ts
+++ b/src/types/node-element.ts
@@ -12,6 +12,12 @@ export type StyleProps = {
   lineHeight?: number;
   fontFamily?: string;
   backgroundColor?: string;
+  display?: string;
+  flexDirection?: string;
+  paddingTop?: number;
+  paddingRight?: number;
+  paddingBottom?: number;
+  paddingLeft?: number;
 };
 
 export type FrameNode = BaseNode & {


### PR DESCRIPTION
## 変更内容
- Auto Layout が HORIZONTAL の場合に display:flex と flexDirection:row を出力
- Frame ノードに padding 系プロパティを出力
- StyleProps 型へ対応するプロパティを追加

## テスト
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` (テスト未設定のため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68a4febf23b48331a88b5e24d4f9dea6