### PR TITLE
Add grid layout parsing for frame nodes

### DIFF
--- a/src/parser/parseFrameNode.ts
+++ b/src/parser/parseFrameNode.ts
@@ -21,6 +21,19 @@ export function parseFrameNode(node: any): FrameNode | BoxNode {
     style.flexDirection = "row";
   }
 
+  if (node.layoutMode === "GRID") {
+    style.display = "grid";
+    if (typeof node.gridColumnCount === "number") {
+      style.gridTemplateColumns = `repeat(${node.gridColumnCount}, 1fr)`;
+    }
+    if (typeof node.gridRowGap === "number") {
+      style.gridRowGap = node.gridRowGap;
+    }
+    if (typeof node.gridColumnGap === "number") {
+      style.gridColumnGap = node.gridColumnGap;
+    }
+  }
+
   if (typeof node.paddingTop === "number") {
     style.paddingTop = node.paddingTop;
   }

--- a/src/types/node-element.ts
+++ b/src/types/node-element.ts
@@ -14,6 +14,9 @@ export type StyleProps = {
   backgroundColor?: string;
   display?: string;
   flexDirection?: string;
+  gridTemplateColumns?: string;
+  gridRowGap?: number;
+  gridColumnGap?: number;
   paddingTop?: number;
   paddingRight?: number;
   paddingBottom?: number;


### PR DESCRIPTION
## Summary
- layoutMode が `GRID` の場合に CSS Grid を出力するよう対応
- `gridColumnCount` を元に列数を指定
- `gridRowGap` と `gridColumnGap` をスタイルに設定できるように調整

## Testing
- `npm test` (失敗: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68a5d9c5048c83319d91ade544af08e2