### PR TITLE
feat: add tailwind classes for frame styles

### DIFF
--- a/src/parser/parseFrameNode.ts
+++ b/src/parser/parseFrameNode.ts
@@ -1,4 +1,5 @@
 import { FrameNode, BoxNode } from "../types/node-element";
+import { cn } from "../utils/cn";
 
 export function parseFrameNode(node: any): FrameNode | BoxNode {
   const name = node.name ?? "";
@@ -12,42 +13,55 @@ export function parseFrameNode(node: any): FrameNode | BoxNode {
   }
 
   const style: Record<string, any> = {};
+  const tw: string[] = [];
   if (node.fills?.[0]?.color) {
     style.backgroundColor = rgbaFromColor(node.fills[0].color);
+    tw.push(`bg-[${style.backgroundColor.replace(/\s/g, "")}]`);
   }
 
   if (node.layoutMode === "HORIZONTAL") {
     style.display = "flex";
     style.flexDirection = "row";
+    tw.push("flex", "flex-row");
   }
 
   if (node.layoutMode === "GRID") {
     style.display = "grid";
+    tw.push("grid");
     if (typeof node.gridColumnCount === "number") {
       style.gridTemplateColumns = `repeat(${node.gridColumnCount}, 1fr)`;
+      tw.push(`grid-cols-${node.gridColumnCount}`);
     }
     if (typeof node.gridRowGap === "number") {
       style.gridRowGap = node.gridRowGap;
+      tw.push(`gap-y-[${node.gridRowGap}px]`);
     }
     if (typeof node.gridColumnGap === "number") {
       style.gridColumnGap = node.gridColumnGap;
+      tw.push(`gap-x-[${node.gridColumnGap}px]`);
     }
   }
 
   if (typeof node.paddingTop === "number") {
     style.paddingTop = node.paddingTop;
+    tw.push(`pt-[${node.paddingTop}px]`);
   }
   if (typeof node.paddingRight === "number") {
     style.paddingRight = node.paddingRight;
+    tw.push(`pr-[${node.paddingRight}px]`);
   }
   if (typeof node.paddingBottom === "number") {
     style.paddingBottom = node.paddingBottom;
+    tw.push(`pb-[${node.paddingBottom}px]`);
   }
   if (typeof node.paddingLeft === "number") {
     style.paddingLeft = node.paddingLeft;
+    tw.push(`pl-[${node.paddingLeft}px]`);
   }
 
-  return { type: "box", style };
+  const tailwindClasses = tw.length ? cn(...tw) : undefined;
+
+  return { type: "box", style, ...(tailwindClasses ? { tailwindClasses } : {}) };
 }
 
 function rgbaFromColor(c: any): string {


### PR DESCRIPTION
## 概要
- cnユーティリティを利用してtailwindのクラスを結合
- FrameNode解析時にスタイルに応じてtailwindクラスを追加

## テスト
- `npm test` (失敗: テスト未実装)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a5ec74fbd483319f761209d3722264