### PR TITLE
feat: merge tailwind classes for text nodes

### DIFF
--- a/dist/parser/parseTextNode.js
+++ b/dist/parser/parseTextNode.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.parseTextNode = parseTextNode;
+const cn_1 = require("../utils/cn");
 function parseTextNode(node) {
     var _a, _b, _c, _d, _e, _f, _g, _h, _j;
     const lineHeightValue = typeof ((_a = node.style) === null || _a === void 0 ? void 0 : _a.lineHeightPercentFontSize) === "number"
@@ -9,21 +10,32 @@ function parseTextNode(node) {
             typeof ((_c = node.style) === null || _c === void 0 ? void 0 : _c.fontSize) === "number"
             ? node.style.lineHeightPx / node.style.fontSize
             : undefined;
-    return {
-        type: "text",
-        content: (_d = node.characters) !== null && _d !== void 0 ? _d : "",
-        style: {
-            fontSize: (_e = node.style) === null || _e === void 0 ? void 0 : _e.fontSize,
-            fontWeight: (_f = node.style) === null || _f === void 0 ? void 0 : _f.fontWeight,
-            lineHeight: typeof lineHeightValue === "number"
-                ? Math.round(lineHeightValue * 100) / 100
-                : undefined,
-            fontFamily: (_g = node.style) === null || _g === void 0 ? void 0 : _g.fontFamily,
-            color: ((_j = (_h = node.fills) === null || _h === void 0 ? void 0 : _h[0]) === null || _j === void 0 ? void 0 : _j.color)
-                ? rgbaFromColor(node.fills[0].color)
-                : undefined,
-        },
-    };
+    const style = {};
+    const tw = [];
+    if (typeof ((_d = node.style) === null || _d === void 0 ? void 0 : _d.fontSize) === "number") {
+        style.fontSize = node.style.fontSize;
+        tw.push(`text-[${node.style.fontSize}px]`);
+    }
+    if (typeof ((_e = node.style) === null || _e === void 0 ? void 0 : _e.fontWeight) === "number") {
+        style.fontWeight = node.style.fontWeight;
+        tw.push(`font-[${node.style.fontWeight}]`);
+    }
+    if (typeof lineHeightValue === "number") {
+        const lineHeight = Math.round(lineHeightValue * 100) / 100;
+        style.lineHeight = lineHeight;
+        tw.push(`leading-[${lineHeight}]`);
+    }
+    if (typeof ((_f = node.style) === null || _f === void 0 ? void 0 : _f.fontFamily) === "string") {
+        style.fontFamily = node.style.fontFamily;
+        const fontFamily = node.style.fontFamily.replace(/'/g, "\\'");
+        tw.push(`font-['${fontFamily}']`);
+    }
+    if ((_h = (_g = node.fills) === null || _g === void 0 ? void 0 : _g[0]) === null || _h === void 0 ? void 0 : _h.color) {
+        style.color = rgbaFromColor(node.fills[0].color);
+        tw.push(`text-[${style.color.replace(/\s/g, "")}]`);
+    }
+    const tailwindClasses = tw.length ? (0, cn_1.cn)(...tw) : undefined;
+    return Object.assign({ type: "text", content: (_j = node.characters) !== null && _j !== void 0 ? _j : "", style }, (tailwindClasses ? { tailwindClasses } : {}));
 }
 function rgbaFromColor(c) {
     const r = Math.round(c.r * 255);

--- a/dist/utils/cn.js
+++ b/dist/utils/cn.js
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cn = cn;
+const clsx_1 = require("clsx");
+const tailwind_merge_1 = require("tailwind-merge");
+function cn(...inputs) {
+    return (0, tailwind_merge_1.twMerge)((0, clsx_1.clsx)(inputs));
+}

--- a/src/parser/parseTextNode.ts
+++ b/src/parser/parseTextNode.ts
@@ -1,4 +1,5 @@
 import { TextNode } from "../types/node-element";
+import { cn } from "../utils/cn";
 
 export function parseTextNode(node: any): TextNode {
   const lineHeightValue =
@@ -9,21 +10,43 @@ export function parseTextNode(node: any): TextNode {
         ? node.style.lineHeightPx / node.style.fontSize
         : undefined;
 
+  const style: Record<string, any> = {};
+  const tw: string[] = [];
+
+  if (typeof node.style?.fontSize === "number") {
+    style.fontSize = node.style.fontSize;
+    tw.push(`text-[${node.style.fontSize}px]`);
+  }
+
+  if (typeof node.style?.fontWeight === "number") {
+    style.fontWeight = node.style.fontWeight;
+    tw.push(`font-[${node.style.fontWeight}]`);
+  }
+
+  if (typeof lineHeightValue === "number") {
+    const lineHeight = Math.round(lineHeightValue * 100) / 100;
+    style.lineHeight = lineHeight;
+    tw.push(`leading-[${lineHeight}]`);
+  }
+
+  if (typeof node.style?.fontFamily === "string") {
+    style.fontFamily = node.style.fontFamily;
+    const fontFamily = node.style.fontFamily.replace(/'/g, "\\'");
+    tw.push(`font-['${fontFamily}']`);
+  }
+
+  if (node.fills?.[0]?.color) {
+    style.color = rgbaFromColor(node.fills[0].color);
+    tw.push(`text-[${style.color.replace(/\s/g, "")}]`);
+  }
+
+  const tailwindClasses = tw.length ? cn(...tw) : undefined;
+
   return {
     type: "text",
     content: node.characters ?? "",
-    style: {
-      fontSize: node.style?.fontSize,
-      fontWeight: node.style?.fontWeight,
-      lineHeight:
-        typeof lineHeightValue === "number"
-          ? Math.round(lineHeightValue * 100) / 100
-          : undefined,
-      fontFamily: node.style?.fontFamily,
-      color: node.fills?.[0]?.color
-        ? rgbaFromColor(node.fills[0].color)
-        : undefined,
-    },
+    style,
+    ...(tailwindClasses ? { tailwindClasses } : {}),
   };
 }
 


### PR DESCRIPTION
## 概要
- テキストノードのスタイル適用時に対応するTailwind CSSクラスを付与
- cnユーティリティでクラス競合を解消

## テスト
- `npm test` (エラー: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a5f2f06e288331b726fb56a2143546